### PR TITLE
Use collections to render lists of projects

### DIFF
--- a/sanity/package-lock.json
+++ b/sanity/package-lock.json
@@ -2042,6 +2042,11 @@
         }
       }
     },
+    "autosize": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2135,6 +2140,11 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "bail": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2565,6 +2575,21 @@
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
       "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
+    "character-entities": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -2687,6 +2712,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "collapse-white-space": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2760,6 +2790,11 @@
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
       }
+    },
+    "computed-style": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3649,6 +3684,21 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+      "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+      "requires": {
+        "domelementtype": "^2.0.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        }
       }
     },
     "domutils": {
@@ -5508,6 +5558,45 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
+    "html-to-react": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
+      "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+      "requires": {
+        "domhandler": "^3.0",
+        "htmlparser2": "^4.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      }
+    },
+    "htmlparser2": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.0.0.tgz",
+      "integrity": "sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "domutils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
+          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "requires": {
+            "dom-serializer": "^0.2.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0"
+          }
+        }
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -5737,6 +5826,20 @@
         }
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -5813,6 +5916,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-decimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
     },
     "is-deflate": {
       "version": "1.0.0",
@@ -5893,6 +6001,11 @@
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
     },
+    "is-hexadecimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+    },
     "is-hotkey": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.6.tgz",
@@ -5938,6 +6051,11 @@
       "requires": {
         "symbol-observable": "^0.2.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6001,6 +6119,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-whitespace-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+    },
     "is-window": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
@@ -6010,6 +6133,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-word-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -6228,6 +6356,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "line-height": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+      "integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
+      "requires": {
+        "computed-style": "~0.1.3"
       }
     },
     "load-json-file": {
@@ -6474,6 +6610,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-escapes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -6492,6 +6633,14 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdast-add-list-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+      "requires": {
+        "unist-util-visit-parents": "1.1.2"
       }
     },
     "mdn-data": {
@@ -7223,6 +7372,19 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-headers": {
@@ -9191,6 +9353,11 @@
         }
       }
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9247,6 +9414,16 @@
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1"
+      }
+    },
+    "react-autosize-textarea": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-5.0.1.tgz",
+      "integrity": "sha512-VHYFObl0XtI4xy2pEMqKDIFCOs1e4JEaDaq2WgwZAZdXrahspnzJAX+Zy4V9eKZIhY+lUKA2MlVZxtqexx/7YA==",
+      "requires": {
+        "autosize": "^4.0.2",
+        "line-height": "^0.3.1",
+        "prop-types": "^15.5.6"
       }
     },
     "react-click-outside": {
@@ -9403,6 +9580,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-markdown": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.2.2.tgz",
+      "integrity": "sha512-/STJiRFmJuAIUdeBPp/VyO5bcenTIqP3LXuC3gYvregmYGKjnszGiFc2Ph0LsWC17Un3y/CT8TfxnwJT7v9EJw==",
+      "requires": {
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "remark-parse": "^5.0.0",
+        "unified": "^6.1.5",
+        "unist-util-visit": "^1.3.0",
+        "xtend": "^4.0.1"
+      }
     },
     "react-measure": {
       "version": "2.3.0",
@@ -9729,6 +9921,28 @@
         }
       }
     },
+    "remark-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -9743,6 +9957,11 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.0",
@@ -9991,6 +10210,19 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/same-origin/-/same-origin-0.1.1.tgz",
       "integrity": "sha1-wih9MZJXffUXrLvW0UUanDw5FPU="
+    },
+    "sanity-plugin-markdown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-markdown/-/sanity-plugin-markdown-1.0.1.tgz",
+      "integrity": "sha512-sePQ+Eikn7D8Gwp5C2+iG3vsw5MrpuJtl/aI2dZD03VtHLPJtih5dwJAt2O8N+7kzFGjzkEcCewKu2v7qu8C7A==",
+      "requires": {
+        "diff-match-patch": "^1.0.4",
+        "react-autosize-textarea": "^5.0.0",
+        "react-icon-base": "^2.1.2",
+        "react-icons": "^2.2.7",
+        "react-markdown": "^4.0.2",
+        "textarea-editor": "^2.1.1"
+      }
     },
     "sax": {
       "version": "1.2.4",
@@ -10581,6 +10813,11 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "state-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -10929,6 +11166,14 @@
         }
       }
     },
+    "textarea-editor": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textarea-editor/-/textarea-editor-2.1.1.tgz",
+      "integrity": "sha512-k+hhOXPlH0TwXr8fuYtu+tq8JgfRcqxFghf9QGVI7zXcW5OzCH6x5SKXQMk5GOE0vym9t1e7WxnNwJjJE/Rn+A==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -11035,6 +11280,21 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+    },
+    "trough": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
     },
     "tslib": {
       "version": "1.10.0",
@@ -11150,6 +11410,15 @@
         "webpack-sources": "^1.0.1"
       }
     },
+    "unherit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -11173,6 +11442,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
+    },
+    "unified": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -11202,6 +11484,47 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+      "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
     },
     "units-css": {
       "version": "0.4.0",
@@ -11387,6 +11710,30 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "requires": {
+        "is-buffer": "^1.1.4",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+    },
+    "vfile-message": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "requires": {
+        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "viewport-dimensions": {
@@ -11793,6 +12140,11 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/sanity/schemas/collection.js
+++ b/sanity/schemas/collection.js
@@ -1,0 +1,45 @@
+const collection = {
+  title: "Collection",
+  name: "collection",
+  type: "document",
+  fields: [
+    {
+      title: "Name",
+      name: "name",
+      required: true,
+      type: "string",
+    },
+    {
+      title: "Description",
+      name: "description",
+      type: "string",
+    },
+    {
+      title: "Slug",
+      name: "slug",
+      required: true,
+      type: "string",
+    },
+    {
+      title: "Feature",
+      name: "feature",
+      description: "A collection auto-generated from a corresponding feature",
+      type: "reference",
+      to: [{ type: "feature" }],
+    },
+    {
+      title: "Projects",
+      description: "A custom collection of projects",
+      name: "projects",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "project" }],
+        },
+      ],
+    },
+  ],
+}
+
+export default collection

--- a/sanity/schemas/layout.js
+++ b/sanity/schemas/layout.js
@@ -1,0 +1,29 @@
+const layout = {
+  title: "Layout",
+  name: "layout",
+  type: "document",
+  fields: [
+    {
+      title: "Name",
+      name: "name",
+      required: true,
+      type: "string",
+    },
+    {
+      title: "page_id",
+      name: "page_id",
+      required: true,
+      type: "string",
+    },
+    {
+      title: "Collections",
+      name: "collections",
+      description:
+        "An array of collections, ordered as they should be displayed in the UI",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "collection" }] }],
+    },
+  ],
+}
+
+export default layout

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -1,11 +1,13 @@
 import createSchema from "part:@sanity/base/schema-creator"
 import schemaTypes from "all:part:@sanity/base/schema-type"
 
+import collection from "./collection"
 import feature from "./feature"
+import layout from "./layout"
 import link from "./link"
 import project from "./project"
 
 export default createSchema({
   name: "default",
-  types: schemaTypes.concat([feature, link, project]),
+  types: schemaTypes.concat([collection, feature, layout, link, project]),
 })

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -3,9 +3,11 @@ import { graphql } from "gatsby"
 import Img from "gatsby-image"
 
 import Layout from "../components/layout"
+import Markdown from "../components/markdown"
+import RelatedProject from "../components/project"
 import SEO from "../components/seo"
 
-import Markdown from "../components/markdown"
+import { flatten, normalizeCollection } from "../utils"
 
 import "../pages/built-with-workers-page.css"
 import "./project-page.css"
@@ -31,7 +33,27 @@ const getLinkText = (linkType) => {
   }
 }
 
-const Project = ({ data: { sanityProject: project } }) => {
+const Project = ({
+  data: {
+    allSanityCollection,
+    allSanityFeature,
+    allSanityProject,
+    sanityProject: project,
+  },
+}) => {
+  const allCollections = flatten(allSanityCollection)
+  let collections = allCollections.map(collection =>
+    normalizeCollection(
+      collection,
+      flatten(allSanityFeature),
+      flatten(allSanityProject)
+    )
+  )
+
+  const collectionForProject = collections.find(({ projects }) =>
+    projects.find(({ id }) => id === project.id)
+  )
+
   return (
     <Layout>
       <SEO title={project.name} />
@@ -97,91 +119,15 @@ const Project = ({ data: { sanityProject: project } }) => {
             </div>
 
             <div className="Collection--projects">
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
+              {collectionForProject.projects
+                .filter(({ id }) => id !== project.id)
+                .map(project => (
+                  <div className="Collection--project" key={project.id}>
+                    <RelatedProject project={project} />
                   </div>
-                </a>
-              </div>
+                ))}
 
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
-                  </div>
-                </a>
-              </div>
-
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
-                  </div>
-                </a>
-              </div>
-
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
-                  </div>
-                </a>
-              </div>
-
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
-                  </div>
-                </a>
-              </div>
-
-              <div className="Collection--project">
-                <a className="Project---link Project---link-fills-height">
-                  <div className="Project Project-fills-height">
-                    <div className="Project--image">
-                      <img title="ProPublica screenshot" src="https://cdn.sanity.io/images/0s2zavz0/production/4f5788b38acdf7bed5674c6ff8940c0d1d8c5dad-2880x1800.png?w=880&h=550&fit=crop&fm=webp"/>
-                    </div>
-                    <div className="Project--content">
-                      <h2 className="Project--title">ProPublica</h2>
-                      <p className="Project--description">An independent, non-profit newsroom that produces investigative journalism in the public interest.</p>
-                    </div>
-                  </div>
-                </a>
-              </div>
-
-              <div className="Collection--spacer"/>
+              <div className="Collection--spacer" />
             </div>
           </div>
         </div>
@@ -194,6 +140,37 @@ export const query = graphql`
   query ProjectPage($slug: String!) {
     sanityProject(slug: { eq: $slug }) {
       ...Project
+    }
+
+    allSanityFeature {
+      edges {
+        node {
+          ...Feature
+        }
+      }
+    }
+
+    allSanityProject {
+      edges {
+        node {
+          ...Project
+        }
+      }
+    }
+
+    allSanityCollection {
+      edges {
+        node {
+          ...Collection
+          feature {
+            ...Feature
+          }
+
+          projects {
+            ...Project
+          }
+        }
+      }
     }
   }
 `

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+const flatten = set => set.edges.map(({ node }) => node)
+
+const normalizeCollection = (collection, features, projects) => {
+  let normalized = collection
+  if (collection.feature) {
+    const featureId = collection.feature.id
+    const feature = features.find(({ id }) => featureId === id)
+    normalized.feature = feature
+    const featureProjects = projects.filter(project =>
+      project.features.find(({ id }) => id === feature.id)
+    )
+    normalized.projects = featureProjects
+  }
+
+  if (collection.projects.length) {
+    const collectionProjects = collection.projects.map(({ id }) =>
+      projects.find(project => project.id === id)
+    )
+    normalized.projects = collectionProjects
+  }
+
+  return normalized
+}
+
+export { flatten, normalizeCollection }


### PR DESCRIPTION
This PR adds support for collections, which are groups of projects that are rendered in the UI. A collection can be tied to a single feature, and will automatically render the list of projects for that feature, or it can be manually added to, allowing for custom collections based on a theme.

It also adds "Layout", a data model that can be used to order collections. The "homepage" layout is a special object (that exists in staging and will be ported to production) to allow the list of collections on the root path to be dynamically updated and re-ordered.

Finally, the "Related Projects" section of the project page, which has been hardcoded with example projects, now looks for the first collection it can find that the current project exists in, and renders the remainder of the projects from that collection.

Closes #17