### PR TITLE
Fix browser history issue

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,10 @@
+import {globalHistory} from '@reach/router';
+
+export const onInitialClientRender = () => {
+  /**
+   * This is a workaround for a bug in Gatsby
+   *
+   * See https://github.com/gatsbyjs/gatsby/issues/8357 for more details
+   */
+  globalHistory._onTransitionComplete();
+}


### PR DESCRIPTION
This isn't an ideal fix, but this bug is apparently a known thing in Gatsby and the suggested solution [here](https://github.com/gatsbyjs/gatsby/issues/8357#issuecomment-453589354) has resolved #35. We considered fixing this in our Workers script but we generally want the Workers part of this to be as out of the box as possible, so we're resolving on the Gatsby side instead.

Closes #35