### PR TITLE
Re-add React version of latency feature on landing page

### DIFF
--- a/src/components/latency_test.js
+++ b/src/components/latency_test.js
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react"
+
+const states = {
+  INIT: "init",
+  TESTING: "testing",
+  TESTED: "tested",
+  ERROR: "error",
+}
+
+const getLatencyToCloudflare = async () => {
+  const TEST_URL = "https://1.1.1.1/cdn-cgi/trace"
+  const NUM_TESTS = 5
+
+  let started = 0
+  async function load() {
+    started++
+
+    await fetch(TEST_URL, {
+      mode: "no-cors",
+      cache: "no-store",
+    })
+
+    if (started <= NUM_TESTS) await load()
+  }
+
+  await load()
+  let entries = performance.getEntriesByName(TEST_URL, "resource")
+  let min = null
+
+  for (
+    let i = Math.max(0, entries.length - NUM_TESTS);
+    i < entries.length;
+    i++
+  ) {
+    // iOS Safari doesn’t report duration
+    const duration =
+      entries[i].duration || entries[i].responseEnd - entries[i].fetchStart
+
+    if (!min || duration < min) min = duration
+  }
+
+  return min | 0
+}
+
+export default () => {
+  const [state, setState] = useState(states.INIT)
+  const [latency, setLatency] = useState(null)
+
+  const testLatency = async () => {
+    try {
+      setState(states.TESTING)
+      const newLatency = await getLatencyToCloudflare()
+      if (isNaN(newLatency) || newLatency === 0 || newLatency > 50)
+        setLatency(null)
+
+      setLatency(newLatency)
+      setState(states.TESTED)
+    } catch (err) {
+      setState(states.ERROR)
+    }
+  }
+
+  useEffect(testLatency, [])
+
+  return [states.INIT, states.ERROR].includes(state) ? null : (
+    <p className="BenefitsSection--benefit-description-latency-test">
+      Your actual latency:{" "}
+      {latency && (
+        <span className="BenefitsSection--benefit-description-latency-test-value">
+          {latency} ms
+        </span>
+      )}{" "}
+      <span className="BenefitsSection--benefit-description-latency-test-button">
+        <button
+          className="Button Button-is-secondary-orange"
+          disabled={state !== states.TESTED}
+          onClick={testLatency}
+        >
+          Test again
+        </button>
+      </span>
+    </p>
+  )
+}

--- a/src/components/latency_test.js
+++ b/src/components/latency_test.js
@@ -25,7 +25,7 @@ const getLatencyToCloudflare = async () => {
 
   await load()
   let entries = performance.getEntriesByName(TEST_URL, "resource")
-  let min = null
+  let min = Infinity
 
   for (
     let i = Math.max(0, entries.length - NUM_TESTS);
@@ -36,7 +36,7 @@ const getLatencyToCloudflare = async () => {
     const duration =
       entries[i].duration || entries[i].responseEnd - entries[i].fetchStart
 
-    if (!min || duration < min) min = duration
+    if (duration < min) min = duration
   }
 
   return min | 0

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 
+import LatencyTest from '../components/latency_test'
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
@@ -124,7 +125,7 @@ const IndexPage = () => {
               <div className="BenefitsSection--benefit-description">
                 <div className="MarkdownLite">
                   <p>Every deploy is made to a network of data centers running <span className="PopoverTarget" data-js-popover="isolates">V8 isolates</span>. Your code is powered by Cloudflare’s network which is milliseconds away from virtually every Internet user.</p>
-                  <p className="BenefitsSection--benefit-description-latency-test" data-js-latency-test>Your actual latency: <span className="BenefitsSection--benefit-description-latency-test-value" data-js-latency-test-value></span> <span className="BenefitsSection--benefit-description-latency-test-button"><button className="Button Button-is-secondary-orange" data-js-latency-test-retry-button>Test again</button></span></p>
+                  <LatencyTest />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This PR fixes the latency feature that existed on the landing page before we migrated repos. That feature is re-added and refactored a little bit to work in React.

<img width="472" alt="Screen Shot 2020-03-11 at 3 49 17 PM" src="https://user-images.githubusercontent.com/922353/76462538-dc058f80-63af-11ea-89d0-f07a3f1d0d20.png">
