### PR TITLE
Fix latency test syntax

### DIFF
--- a/src/components/latency_test.js
+++ b/src/components/latency_test.js
@@ -60,7 +60,9 @@ export default () => {
     }
   }
 
-  useEffect(testLatency, [])
+  useEffect(() => {
+    testLatency()
+  }, [])
 
   return [states.INIT, states.ERROR].includes(state) ? null : (
     <p className="BenefitsSection--benefit-description-latency-test">


### PR DESCRIPTION
This fixes an issue where the latency test component causes page transitions to fail when leaving the root route of the site. Turns out returning a promise as the response to useEffect is bad!