### PR TITLE
Remove hourly deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
   repository_dispatch:
-  schedule:
-    - cron: "0 * * * *"
 
 jobs:
   deploy:


### PR DESCRIPTION
Builds are based on repository_dispatch and master changes so we should always get up to date builds