### PR TITLE
New pages

### DIFF
--- a/src/components/content-page.js
+++ b/src/components/content-page.js
@@ -1,0 +1,49 @@
+// Experimental content page component for
+// consistent rendering across some of our newer
+// content
+
+import React, { useEffect, useRef } from 'react'
+import { setup, tw } from 'twind'
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+// Setup dark mode class config
+setup({ darkMode: 'class' })
+
+const ContentPage = ({ image, link, title, description, cta, children }) => {
+  const content = useRef(null)
+
+  useEffect(() => {
+    const htmlSelector = document.querySelector("html")
+    const theme = htmlSelector.getAttribute("theme")
+    theme === "dark" && htmlSelector.classList.add("dark")
+
+    content.current.hidden = false
+  }, [])
+
+  return (
+    <div className={tw`antialiased text-black dark:text-white mx-4`} hidden ref={content}>
+      <div className={tw`md:max-w-4xl mx-auto pt-16`}>
+        <div className={tw`mt-16 mb-8 flex items-start align-middle`}>
+          {image ? <img className={tw`w-24 mr-8 mt-2`} alt="Workers logo" src={image} /> : null}
+          <div className={tw`flex-1`}>
+            <h1 className={tw`text-4xl mb-4 font-bold`}>{title}</h1>
+            <h2 className={tw`text-lg max-w-xl`}>{description}</h2>
+          </div>
+          {link ?
+            <a className={
+              [`Button Button-is-primary`, tw`text-xl mt-2`].join(' ')
+            }
+              href={link.url}>{link.text}</a>
+            : null}
+        </div>
+      </div>
+
+      <div className={tw`md:max-w-4xl mx-auto pt-8`}>
+        {children}
+      </div>
+    </div >
+  )
+}
+
+export default ContentPage

--- a/src/pages/node.js
+++ b/src/pages/node.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { tw } from 'twind'
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+import ContentPage from '../components/content-page'
+
+const NodePage = () => {
+  return (
+    <Layout>
+      <SEO title="Building Node.js Support" />
+
+      <ContentPage
+        description="Vote on which Node.js-dependent libraries & APIs that Cloudflare Workers should support"
+        image="/resources/logo/logo.svg"
+        title="Building Node.js Support"
+        link={{ text: "Vote", url: "https://airtable.com/shrM9MdUR8ojbUdSZ" }}
+      >
+        <>
+          <div>
+            <iframe
+              className="airtable-embed"
+              src="https://airtable.com/embed/shrSMXSIQ5TI70XwV?backgroundColor=yellow&viewControls=on"
+              frameborder="0"
+              onmousewheel=""
+              width="100%"
+              height="600"
+              style={{ background: 'transparent', border: '1px solid #ccc' }}
+            />
+          </div>
+
+          <div className={tw`md:max-w-4xl mx-auto mt-12 pt-8 pb-32`}>
+            <h2 className={tw`text-4xl pt-4 pb-12`}>Frequently Asked Questions</h2>
+
+            <h3 className={tw`text-xl font-semibold`}>What support does Cloudflare Workers currently offer for Node.js?</h3>
+
+            <p className={tw`text-lg py-4`}>
+              The Workers runtime supports any Node.js package that doesn't rely on native code (e.g. C). You can use webpack (if the package supports it) to bundle up your Node.js dependencies and deploy to Workers using our CLI tool, <a className={tw`Link`} href="https://developers.cloudflare.com/workers/cli-wrangler/webpack">webpack</a>. Also, with <a className={tw`Link`} href="https://developers.cloudflare.com/workers/runtime-apis/durable-objects">Durable Objects</a>, you can use our new modules API that allows you to upload Workers as <a className={tw`Link`} href="https://github.com/cloudflare/wrangler/pull/1807">ES Modules</a>.
+          </p>
+
+            <h3 className={tw`text-xl font-semibold pt-4`}>How can I keep track on the latest news about Node.js support and other Workers products? </h3>
+
+            <p className={tw`text-lg py-4`}>
+              Please come visit us in the <a className={tw`Link`} href="https://discord.gg/cloudflaredev">Workers Discord</a>, where the team regularly shares updates on the roadmap!
+          </p>
+          </div>
+        </>
+      </ContentPage>
+    </Layout >
+  )
+}
+
+export default NodePage

--- a/src/pages/works.js
+++ b/src/pages/works.js
@@ -1,36 +1,22 @@
-import React, { useEffect, useRef } from 'react'
-import { setup, tw } from 'twind'
+import React from 'react'
+import { tw } from 'twind'
+import ContentPage from "../components/content-page"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-// Setup dark mode class config
-setup({ darkMode: 'class' })
-
 const WorksPage = () => {
-  const content = useRef(null)
-
-  useEffect(() => {
-    const htmlSelector = document.querySelector("html")
-    const theme = htmlSelector.getAttribute("theme")
-    theme === "dark" && htmlSelector.classList.add("dark")
-
-    content.current.hidden = false
-  }, [])
-
   return (
     <Layout>
       <SEO title="Works on Workers" />
 
-      <div className={tw`antialiased text-black dark:text-white mx-4`} hidden ref={content}>
-        <div className={tw`md:max-w-4xl mx-auto pt-16 pb-8`}>
-          <div className={tw`text-center mt-16 mb-12`}>
-            <h1 className={tw`text-4xl mb-4 font-bold`}>Works on Workers</h1>
-            <h2 className={tw`text-xl`}>
-              The best packages and libraries supported by Cloudflare Workers, chosen by <a className={tw`Link`} href="https://discord.gg/cloudflaredev">our community</a>
-            </h2>
-          </div>
-
-          <div className={tw`text-center`}>
+      <ContentPage
+        description="The best packages and libraries supported by Cloudflare Workers, chosen by our community"
+        image="/resources/logo/logo.svg"
+        title="Works on Workers"
+        link={{ text: "Submit package", url: "https://airtable.com/shrtvoM4QfEr48ZoQ" }}
+      >
+        <>
+          <div>
             <iframe
               className="airtable-embed"
               src="https://airtable.com/embed/shrTR0QCusxZoCgiJ?backgroundColor=yellow&viewControls=on"
@@ -40,41 +26,39 @@ const WorksPage = () => {
               height="800"
               style={{ background: 'transparent', border: '1px solid #ccc' }}
             />
-            <p className={tw`my-4`}>
-              <a className={tw`Link`} href="https://airtable.com/shrtvoM4QfEr48ZoQ">Submit new packages</a>
+          </div>
+
+          <div className={tw`md:max-w-4xl mx-auto mt-12 pt-8 pb-32`}>
+            <h2 className={tw`text-4xl pt-4 pb-12`}>Frequently Asked Questions</h2>
+
+            <h3 className={tw`text-xl font-semibold`}>Does Workers supports React/Angular/Svelte/your frontend framework of choice?</h3>
+
+            <p className={tw`text-lg py-4`}>
+              Workers supports some server-rendered solutions for frameworks like React and Svelte. We
+              generally suggest these solutions for power-users, and recommend that developers deploying front-end applications check out our
+              deployment platform Cloudflare Pages.
+            </p>
+
+            <h3 className={tw`text-xl font-semibold pt-4`}>A package that you suggested doesn't work!</h3>
+
+            <p className={tw`text-lg py-4`}>
+              Some packages may require special configuration (see the "Notes" section for each package). If a package is listed on our list that isn't supported, you can reach out to us on the <a className="Link" href="https://discord.gg/cloudflaredev">Cloudflare Workers Discord server</a> and we'll get it removed as soon as possible.
+            </p>
+
+            <h3 className={tw`text-xl font-semibold pt-4`}>What packages don't work?</h3>
+
+            <p className={tw`text-lg py-4`}>
+              Many packages that require <em>Node dependencies</em>, such as <code>fs</code> or <code>net/http</code>, aren't supported in Workers because Workers isn't Node—it's <a className="Link" href="https://developers.cloudflare.com/workers/learning/how-workers-works">built on V8</a>.
+            </p>
+
+            <p className={tw`text-lg`}>
+              If you're using browser packages in Workers, you should be aware that many of them refer to <code>window</code>—the instance of the browser window. This isn't supported in Workers (because it runs in V8, not on a browser window).
             </p>
           </div>
-        </div>
+        </>
 
-        <div className={tw`md:max-w-3xl mx-auto mt-12 pt-8 pb-32`}>
-          <h2 className={tw`text-center text-4xl pt-4 pb-12`}>FAQ</h2>
-
-          <h3 className={tw`text-xl font-semibold`}>Does Workers supports React/Angular/Svelte/your frontend framework of choice?</h3>
-
-          <p className={tw`text-lg py-4`}>
-            Workers supports some server-rendered solutions for frameworks like React and Svelte. We
-            generally suggest these solutions for power-users, and recommend that developers deploying front-end applications check out our
-            deployment platform Cloudflare Pages.
-            </p>
-
-          <h3 className={tw`text-xl font-semibold pt-4`}>A package that you suggested doesn't work!</h3>
-
-          <p className={tw`text-lg py-4`}>
-            Some packages may require special configuration (see the "Notes" section for each package). If a package is listed on our list that isn't supported, you can reach out to us on the <a className="Link" href="https://discord.gg/cloudflaredev">Cloudflare Workers Discord server</a> and we'll get it removed as soon as possible.
-            </p>
-
-          <h3 className={tw`text-xl font-semibold pt-4`}>What packages don't work?</h3>
-
-          <p className={tw`text-lg py-4`}>
-            Many packages that require <em>Node dependencies</em>, such as <code>fs</code> or <code>net/http</code>, aren't supported in Workers because Workers isn't Node—it's <a className="Link" href="https://developers.cloudflare.com/workers/learning/how-workers-works">built on V8</a>.
-            </p>
-
-          <p className={tw`text-lg`}>
-            If you're using browser packages in Workers, you should be aware that many of them refer to <code>window</code>—the instance of the browser window. This isn't supported in Workers (because it runs in V8, not on a browser window).
-            </p>
-        </div>
-      </div>
-    </Layout >
+      </ContentPage>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
- Add "Building Node.js Support"
- Update "Works on Workers" page

This PR adds a new component `content-page` which is a re-usable layout for info-dense content on the site.

Preview tunnel URL sent out on request :)