### PR TITLE
Move to grid layout for built with projects

### DIFF
--- a/src/pages/built-with.js
+++ b/src/pages/built-with.js
@@ -53,7 +53,6 @@ const BuiltWithPage = ({
                       <Project project={project} isInitialRoute={isInitialRoute()} />
                     </div>
                   ))}
-                  <div className="Collection--spacer" />
                 </div>
               </div>
             </div>

--- a/src/pages/built-with.js
+++ b/src/pages/built-with.js
@@ -7,7 +7,7 @@ import Layout from "../components/layout"
 import Project from "../components/project"
 import SEO from "../components/seo"
 
-import { flatten, normalizeCollection } from "../utils"
+import { flatten, normalizeCollection, PROJECTS_PER_COLLECTION } from "../utils"
 
 import "./built-with-workers-page.css"
 import "./collections.css"
@@ -48,7 +48,7 @@ const BuiltWithPage = ({
                 </div>
 
                 <div className="Collection--projects">
-                  {collection.projects.map(project => (
+                  {collection.projects.slice(0, PROJECTS_PER_COLLECTION).map(project => (
                     <div className="Collection--project" key={project.id}>
                       <Project project={project} isInitialRoute={isInitialRoute()} />
                     </div>

--- a/src/pages/collection.css
+++ b/src/pages/collection.css
@@ -52,7 +52,6 @@
 .Collection--header {
   display: flex;
   align-items: center;
-  padding: 0 var(--content-horizontal-padding) .5em;
 }
 
 .Collection--title {
@@ -62,12 +61,9 @@
 /* TODO - put scroll snap stuff inside of @supports (scroll-snap-align: start) */
 
 .Collection--projects {
-  display: flex;
-  overflow-x: scroll;
-  -webkit-overflow-scrolling: touch;
-  scroll-snap-type: x proximity;
-  scroll-padding: var(--content-horizontal-padding);
-  margin-top: -1em;
+  display: grid;
+  grid-template-columns: repeat(var(--columns), var(--project-width));
+  gap: 1em calc(var(--gutter) / 2);
 }
 
 @supports (-webkit-font-smoothing: antialiased) {
@@ -88,17 +84,13 @@
 }
 
 .Collection--project {
-  display: flex;
+  /* display: flex; */
   width: var(--project-width);
-  flex-direction: column;
+  /* flex-direction: column; */
   scroll-snap-align: start;
-  margin: 1em calc(var(--gutter) / 2);
+  margin: 1em 0;
   --border-radius: .5em;
   border-radius: var(--border-radius);
-}
-
-.Collection--project:first-child {
-  margin-left: var(--content-horizontal-padding);
 }
 
 .Collection--spacer {
@@ -117,10 +109,7 @@
 
 .Collection-is-centered .Collection--projects {
   scroll-padding: var(--scroll-padding);
-}
-
-.Collection-is-centered .Collection--project:first-child {
-  margin-left: var(--scroll-padding);
+  justify-content: center;
 }
 
 .Collection-is-centered .Collection--spacer {

--- a/src/pages/collection.css
+++ b/src/pages/collection.css
@@ -24,9 +24,6 @@
 @media (max-width: 1500px) { .Collection { --columns: 3 }}
 @media (max-width: 1200px) { .Collection { --columns: 2 }}
 
-@media (max-width:  768px) and
-       (min-height: 600px) { .Collection { --columns: 1 }}
-
 @media (max-width:  375px) { .Collection { --columns: 1 }}
 
 @media (max-width: 2400px) {
@@ -40,6 +37,14 @@
       /
       (var(--columns) + .5)
     );
+  }
+}
+
+@media (max-width:  768px) and
+       (min-height: 600px) {
+  .Collection {
+    --columns: 1;
+    --project-width: 80vw;
   }
 }
 

--- a/src/pages/collections.css
+++ b/src/pages/collections.css
@@ -1,3 +1,9 @@
+.Collections {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .Collections > .Collections--collection:not(:last-child) {
   margin-bottom: 4em;
 }

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -192,8 +192,6 @@ const Project = ({
                       <RelatedProject project={project} />
                     </div>
                   ))}
-
-              <div className="Collection--spacer" />
             </div>
           </div>
         </div>

--- a/src/templates/project.js
+++ b/src/templates/project.js
@@ -9,7 +9,7 @@ import RelatedProject from "../components/project"
 import SEO from "../components/seo"
 import useBookmarkState from "../components/bookmark_state"
 
-import { flatten, normalizeCollection } from "../utils"
+import { flatten, normalizeCollection, PROJECTS_PER_COLLECTION } from "../utils"
 
 import "../pages/built-with-workers-page.css"
 import "./project-page.css"
@@ -187,6 +187,7 @@ const Project = ({
               {collectionForProject &&
                 collectionForProject.projects
                   .filter(({ id }) => id !== project.id)
+                  .slice(0, PROJECTS_PER_COLLECTION)
                   .map(project => (
                     <div className="Collection--project" key={project.id}>
                       <RelatedProject project={project} />

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,4 +79,6 @@ function useLocalStorage(key, initialValue) {
   return [storedValue, setValue]
 }
 
-export { flatten, normalizeCollection, useLocalStorage, useSSR }
+const PROJECTS_PER_COLLECTION = 6
+
+export { flatten, normalizeCollection, PROJECTS_PER_COLLECTION, useLocalStorage, useSSR }


### PR DESCRIPTION
Horizontal scrolling has been difficult for many viewers of the site - this PR migrates to CSS Grid to make it possible for people to view the site without needing horizontal scroll, or needing to drag scrollbars.

WIP as I do some testing on various browsers/devices