### PR TITLE
Footer: swap newsletter for YouTube

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -33,7 +33,7 @@ const Footer = () => (
         <ul className="Footer--column-list">
           <li className="Footer--column-list-item"><a href="https://developers.cloudflare.com/workers/about/how-it-works/" className="Link Link-without-underline Link-is-juicy">How it works</a></li>
           <li className="Footer--column-list-item"><a href="https://workers.cloudflare.com/built-with" className="Link Link-without-underline Link-is-juicy">Built with</a></li>
-          <li className="Footer--column-list-item"><a href="https://blog.cloudflare.com/serverlist/" className="Link Link-without-underline Link-is-juicy">Newsletter</a></li>
+          <li className="Footer--column-list-item"><a href="https://www.youtube.com/channel/UC3QIolTSR29ba4_u15vtEUQ" className="Link Link-without-underline Link-is-juicy">YouTube</a></li>
           <li className="Footer--column-list-item"><a href="https://blog.cloudflare.com/tag/serverless/" className="Link Link-without-underline Link-is-juicy">Blog</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Closes #166 "
The YouTube channel is partly 'about', partly 'help'... in 'about' it keeps 4 items per column aesthetic.

Removing newsletter link:
There hasn't been a new Newsletter in a year.
So unless you want to hire someone to restart the newsletter (eg me ;) ), be best not to have the link anymore. Besides, Discord & your social media outlets get plenty of action.