### PR TITLE
Update free plan number of workers allowance

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -561,7 +561,7 @@ const IndexPage = () => {
               </div>
               <div className="PlansSection--plan-details">
                 <ul className="UnorderedListWorkersThemed">
-                  <li>Deploy up to 30 Worker scripts</li>
+                  <li>Deploy up to 100 Worker scripts</li>
                   <li>Runs on all 275+ network locations</li>
                   <li>Free workers.dev subdomain</li>
                   <li>Up to 10ms CPU time per request</li>


### PR DESCRIPTION
- Per https://www.cloudflare.com/plans/developer-platform/, free plan users are now allowed up to 100 Workers scripts on their account, not 30.
- This PR is just a one-line change to reflect that.