### PR TITLE
Add sorting and limiting to collections

### DIFF
--- a/app/routes/built-with._index.jsx
+++ b/app/routes/built-with._index.jsx
@@ -6,7 +6,7 @@ import Project from "../components/project";
 import { isInitialRoute } from "../components/route-update-history.js";
 
 import { client } from "../lib/sanity";
-import { PROJECTS_PER_COLLECTION } from "../utils";
+import { PROJECTS_PER_COLLECTION, sortAndLimitProjects } from "../utils";
 
 import "../styles/built-with-workers-page.css";
 import "../styles/collections.css";
@@ -77,8 +77,7 @@ const BuiltWithPage = () => {
                 </div>
 
                 <div className="Collection--projects">
-                  {collection.projects
-                    .slice(0, PROJECTS_PER_COLLECTION)
+                  {sortAndLimitProjects(collection)
                     .map((project, pi) => (
                       <div className="Collection--project" key={pi}>
                         <Project

--- a/app/routes/built-with.collections.$slug.jsx
+++ b/app/routes/built-with.collections.$slug.jsx
@@ -5,7 +5,7 @@ import Layout from "../components/layout";
 import Project from "../components/project";
 import { isInitialRoute } from "../components/route-update-history.js";
 
-import { sortAndLimitProjects } from "../utils";
+import { sortProjects } from "../utils";
 
 import { client } from "../lib/sanity";
 
@@ -59,7 +59,7 @@ const BuiltWithPage = () => {
         <div className="Collections">
           <div className="Collection">
             <div className="Collection--projects">
-              {sortAndLimitProjects(collection)
+              {sortProjects(collection)
                 .map((project, pi) => (
                   <div className="Collection--project" key={pi}>
                     <Project

--- a/app/routes/built-with.collections.$slug.jsx
+++ b/app/routes/built-with.collections.$slug.jsx
@@ -5,6 +5,8 @@ import Layout from "../components/layout";
 import Project from "../components/project";
 import { isInitialRoute } from "../components/route-update-history.js";
 
+import { sortAndLimitProjects } from "../utils";
+
 import { client } from "../lib/sanity";
 
 import "../styles/built-with-workers-page.css";
@@ -57,7 +59,7 @@ const BuiltWithPage = () => {
         <div className="Collections">
           <div className="Collection">
             <div className="Collection--projects">
-              {collection.projects
+              {sortAndLimitProjects(collection)
                 .map((project, pi) => (
                   <div className="Collection--project" key={pi}>
                     <Project

--- a/app/styles/collection.css
+++ b/app/styles/collection.css
@@ -20,19 +20,19 @@
 
 @media (max-width: 2400px) {
   .Collection {
-    --columns: 6
+    --columns: 3
   }
 }
 
 @media (max-width: 2100px) {
   .Collection {
-    --columns: 5
+    --columns: 3
   }
 }
 
 @media (max-width: 1800px) {
   .Collection {
-    --columns: 4
+    --columns: 3
   }
 }
 

--- a/app/utils.jsx
+++ b/app/utils.jsx
@@ -124,11 +124,35 @@ const resultTemplate = () => `
     </div>
   `
 
+const sortAndLimitProjects = (collection) => {
+  const numToShow = collection.numProjectsToShow || 3;
+  const sortOrder = collection.sortOrder || "_updated_at desc";
+  const [sortField, sortDirection] = sortOrder.split(" ");
+
+  const projects = collection.projects
+    .sort((a, b) => {
+      if (sortField === "name") {
+        return a.name.localeCompare(b.name);
+      }
+      if (["_created_at", "_updated_at"].includes(sortField)) {
+        return a[sortField] > b[sortField] ? 1 : -1;
+      }
+      // Not sure, default to created_at desc
+      return a[sortField] > b[sortField] ? 1 : -1;
+    })
+    .slice(0, numToShow)
+
+  return projects;
+}
+
+
+
 export {
   PROJECTS_PER_COLLECTION,
   flatten,
   normalizeCollection,
   resultTemplate,
+  sortAndLimitProjects,
   useLocalStorage,
   useSSR,
 }

--- a/app/utils.jsx
+++ b/app/utils.jsx
@@ -126,6 +126,10 @@ const resultTemplate = () => `
 
 const sortAndLimitProjects = (collection) => {
   const numToShow = collection.numProjectsToShow || 3;
+  return sortProjects(collection).slice(0, numToShow)
+}
+
+const sortProjects = (collection) => {
   const sortOrder = collection.sortOrder || "_updated_at desc";
   const [sortField, sortDirection] = sortOrder.split(" ");
 
@@ -140,18 +144,16 @@ const sortAndLimitProjects = (collection) => {
       // Not sure, default to created_at desc
       return a[sortField] > b[sortField] ? 1 : -1;
     })
-    .slice(0, numToShow)
 
   return projects;
 }
-
-
 
 export {
   PROJECTS_PER_COLLECTION,
   flatten,
   normalizeCollection,
   resultTemplate,
+  sortProjects,
   sortAndLimitProjects,
   useLocalStorage,
   useSSR,

--- a/sanity/schemaTypes/collection.js
+++ b/sanity/schemaTypes/collection.js
@@ -32,6 +32,34 @@ const collection = {
         },
       ],
     },
+    {
+      title: "# of Projects to Show",
+      name: "numProjectsToShow",
+      type: "number",
+      description:
+        "The number of projects to show on the home page. This is used to limit the number of projects to show on the home page.",
+      required: true,
+      type: "number",
+      initalValue: 3,
+    },
+    {
+      title: "Sort Order",
+      name: "sortOrder",
+      type: "string",
+      description:
+        "The sort order for the projects. This is used to sort the projects on the home page.",
+      required: true,
+      options: {
+        list: [
+          { title: "Newest Projects First", value: "_created_at desc" },
+          { title: "Oldest Projects First", value: "_created_at asc" },
+          { title: "Alphabetical", value: "name asc" },
+          { title: "Most Recently Updated", value: "_updated_at desc" },
+          { title: "Least Recently Updated", value: "_updated_at asc" },
+        ],
+      },
+      initialValue: { title: "Newest Projects First" }
+    },
   ],
 }
 


### PR DESCRIPTION
This PR adds two new fields to collections, which change how collections are rendered across the Built With subsection of the site:

- Number of projects to show: hard caps the # of projects shown on the home page
- Sort order: adds a sort order to all collections that pre-sorts the projects and how they get rendered

This PR also limits the number of projects per row shown to 3 max