### PR TITLE
WC-3228 Ensure logo.svg is accessible at /logo.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Make sure to deploy the output of `npm run build`
 
 - `build/server`
 - `build/client`
+
+# Image resources
+
+`logo.svg` is being used by [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) for displaying the Workers logo in pull request comments. Please ensure that this file remains accessible at /logo.svg.

--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -15,7 +15,7 @@ const Footer = () => (
           <img
             className="Footer--logo-link-image"
             alt="Workers logo"
-            src="https://workers.cloudflare.com/resources/logo/logo.svg"
+            src="https://workers.cloudflare.com/logo.svg"
           />
         </a>
       </div>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 416 375">
+  <title>Cloudflare Workers logo</title>
+  <defs>
+    <linearGradient id="CloudflareWorkersLogo--gradient-a" x1="50%" x2="25.7%" y1="100%" y2="8.7%">
+      <stop offset="0%" stop-color="#eb6f07"/>
+      <stop offset="100%" stop-color="#fab743"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-b" x1="81%" x2="40.5%" y1="83.7%" y2="29.5%">
+      <stop offset="0%" stop-color="#d96504"/>
+      <stop offset="100%" stop-color="#d96504" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-c" x1="42%" x2="84%" y1="8.7%" y2="79.9%">
+      <stop offset="0%" stop-color="#eb6f07"/>
+      <stop offset="100%" stop-color="#eb720a" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-d" x1="50%" x2="25.7%" y1="100%" y2="8.7%">
+      <stop offset="0%" stop-color="#ee6f05"/>
+      <stop offset="100%" stop-color="#fab743"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-e" x1="-33.2%" x2="91.7%" y1="100%" y2="0%">
+      <stop offset="0%" stop-color="#d96504" stop-opacity=".8"/>
+      <stop offset="49.8%" stop-color="#d96504" stop-opacity=".2"/>
+      <stop offset="100%" stop-color="#d96504" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-f" x1="50%" x2="25.7%" y1="100%" y2="8.7%">
+      <stop offset="0%" stop-color="#ffa95f"/>
+      <stop offset="100%" stop-color="#ffebc8"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-g" x1="8.1%" x2="96.5%" y1="1.1%" y2="48.8%">
+      <stop offset="0%" stop-color="#fff" stop-opacity=".5"/>
+      <stop offset="100%" stop-color="#fff" stop-opacity=".1"/>
+    </linearGradient>
+    <linearGradient id="CloudflareWorkersLogo--gradient-h" x1="-13.7%" y1="104.2%" y2="46.2%">
+      <stop offset="0%" stop-color="#fff" stop-opacity=".5"/>
+      <stop offset="100%" stop-color="#fff" stop-opacity=".1"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#CloudflareWorkersLogo--gradient-a)" d="M107 5.4l49 88.4-45 81a26 26 0 0 0 0 25.3l45 81.2-49 88.4A52 52 0 0 1 85 349L7 213.5a52.2 52.2 0 0 1 0-52L85 26a52 52 0 0 1 22-20.6z"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-b)" d="M111 174.9a26 26 0 0 0 0 25.2l45 81.2-49 88.4A52 52 0 0 1 85 349L7 213.5C.8 202.8 35.5 190 111 175z" opacity=".7"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-c)" d="M112 14.3l44 79.5-7.3 12.7-38.8-65.7C98.7 22.5 81.6 32 60.2 69l3.2-5.5L85 26a52 52 0 0 1 21.8-20.6l5.1 8.9z" opacity=".5"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-d)" d="M331 26l78 135.5c9.3 16 9.3 36 0 52L331 349a52 52 0 0 1-45 26h-78l97-174.9a26 26 0 0 0 0-25.2L208 0h78a52 52 0 0 1 45 26z"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-e)" d="M282 374.4l-77 .7 93.2-175.8a27 27 0 0 0 0-25.4L205 0h17.6l97.8 173.1a27 27 0 0 1-.1 26.8 15624 15624 0 0 0-62.7 110c-19 33.4-10.8 54.9 24.4 64.5z"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-f)" d="M130 375c-8 0-16-1.9-23-5.3l96.2-173.5c3-5.4 3-12 0-17.4L107 5.4A52 52 0 0 1 130 0h78l97 174.9a26 26 0 0 1 0 25.2L208 375h-78z"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-g)" d="M298.2 178.8L199 0h9l97 174.9a26 26 0 0 1 0 25.2L208 375h-9l99.2-178.8c3-5.4 3-12 0-17.4z" opacity=".6"/>
+  <path fill="url(#CloudflareWorkersLogo--gradient-h)" d="M203.2 178.8L107 5.4c3-1.6 6.6-2.8 10-3.8 21.2 38.1 52.5 95.9 94 173.3a26 26 0 0 1 0 25.2L115.5 373c-3.4-1-5.2-1.7-8.4-3.2l96-173.5c3-5.4 3-12 0-17.4z" opacity=".6"/>
+</svg>

--- a/public/logo.svg.README
+++ b/public/logo.svg.README
@@ -1,0 +1,1 @@
+`logo.svg` is being used by [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) for displaying the Workers logo in pull request comments. Please ensure that this file remains accessible at /logo.svg.


### PR DESCRIPTION
- Updates the readme to highlight this file is being referenced outside of this repository
- Moves logo.svg to the root, updates the footer to the new location