### PR TITLE
Remove origin check

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,25 +12,6 @@ export default <ExportedHandler<Env>>{
       
       // Sanity API proxy endpoint
       if (url.pathname.startsWith("/api/sanity")) {
-        // Security check: Only allow requests from the current domain
-        const origin = request.headers.get("Origin")
-        const referer = request.headers.get("Referer")
-        
-        // Check if the request is coming from the same domain
-        const allowedOrigins = [
-          "https://workers.cloudflare.com",
-          "http://localhost:3000", // For local development
-          "http://localhost:8788"  // For local worker development
-        ]
-        
-        // Verify origin or referer is from allowed domains
-        const isAllowedOrigin = origin && allowedOrigins.some(allowed => origin.startsWith(allowed))
-        const isAllowedReferer = referer && allowedOrigins.some(allowed => referer.startsWith(allowed))
-        
-        if (!isAllowedOrigin && !isAllowedReferer) {
-          return new Response("Forbidden", { status: 403 })
-        }
-
         if (!env.SANITY_TOKEN) {
           return new Response("Sanity token not configured", { status: 500 })
         }


### PR DESCRIPTION
This doesn't appear to work in dev, so I can't reliably test it. Considering that this endpoint still requires a valid Sanity API token to query the database, we should be safe to remove this entirely.